### PR TITLE
Force plugin java code  encoding to UTF-8 before compile

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1382,7 +1382,7 @@
                             <mkdir dir="@{pluginlib}/classes" />
 
                             <!-- copy the source we want to compile -->
-                            <copy todir="@{pluginlib}/source">
+                            <copy todir="@{pluginlib}/source" encoding="utf8">
                                 <fileset dir="@{pluginsrc}/@{plugin}/src/java" includes="**/*.java" />
                                 <filterset>
                                     <filter token="DATE" value="${buildJavaDate}"/>


### PR DESCRIPTION
The plugin java code will be copied to "work/plugins-dev/@{plugin}/work/lib". And compiled after that.The default encoding is ANSI in windows platform. If the java code contains non-english comments, it will be aborted when compiled.